### PR TITLE
Parse weekday names.

### DIFF
--- a/lib/halftime/date_factories.rb
+++ b/lib/halftime/date_factories.rb
@@ -42,6 +42,52 @@ module Halftime
       end
     end
 
+    class Weekday < Ambiguous
+      def self.monday
+        new(1)
+      end
+
+      def self.tuesday
+        new(2)
+      end
+
+      def self.wednesday
+        new(3)
+      end
+
+      def self.thursday
+        new(4)
+      end
+
+      def self.friday
+        new(5)
+      end
+
+      def self.saturday
+        new(6)
+      end
+
+      def self.sunday
+        new(7)
+      end
+
+      def new(current)
+        if current.wday < weekday_number
+          current + (weekday_number - current.wday)
+        else
+          current + (7 - current.wday + weekday_number)
+        end
+      end
+
+      private
+
+      def initialize(weekday_number)
+        @weekday_number = weekday_number
+      end
+
+      attr_reader :weekday_number
+    end
+
     class MonthDay < Ambiguous
       def initialize(month, day)
         @month = month

--- a/lib/halftime/internal_parser.rb
+++ b/lib/halftime/internal_parser.rb
@@ -14,7 +14,8 @@ module Halftime
     end
 
     rule :date do
-      (tomorrow | numerical_date | date_with_month_name).as(:date_factory)
+      (tomorrow | weekday | numerical_date | date_with_month_name).
+        as(:date_factory)
     end
 
     rule :on? do
@@ -23,6 +24,43 @@ module Halftime
 
     rule :tomorrow do
       stri("tomorrow").as(:tomorrow)
+    end
+
+    rule :weekday do
+      next? >>
+        (monday | tuesday | wednesday | thursday | friday | saturday | sunday)
+    end
+
+    rule :next? do
+      stri("next").maybe >> spaces?
+    end
+
+    rule :monday do
+      (stri("monday") | stri("mon")).as(:monday)
+    end
+
+    rule :tuesday do
+      (stri("tuesday") | stri("tue")).as(:tuesday)
+    end
+
+    rule :wednesday do
+      (stri("wednesday") | stri("wed")).as(:wednesday)
+    end
+
+    rule :thursday do
+      (stri("thursday") | stri("thu")).as(:thursday)
+    end
+
+    rule :friday do
+      (stri("friday") | stri("fri")).as(:friday)
+    end
+
+    rule :saturday do
+      (stri("saturday") | stri("sat")).as(:saturday)
+    end
+
+    rule :sunday do
+      (stri("sunday") | stri("sun")).as(:sunday)
     end
 
     rule :numerical_date do

--- a/lib/halftime/transform.rb
+++ b/lib/halftime/transform.rb
@@ -65,6 +65,34 @@ module Halftime
       DateFactories::Tomorrow.new
     end
 
+    rule monday: simple(:monday) do
+      DateFactories::Weekday.monday
+    end
+
+    rule tuesday: simple(:tuesday) do
+      DateFactories::Weekday.tuesday
+    end
+
+    rule wednesday: simple(:wednesday) do
+      DateFactories::Weekday.wednesday
+    end
+
+    rule thursday: simple(:thursday) do
+      DateFactories::Weekday.thursday
+    end
+
+    rule friday: simple(:friday) do
+      DateFactories::Weekday.friday
+    end
+
+    rule saturday: simple(:saturday) do
+      DateFactories::Weekday.saturday
+    end
+
+    rule sunday: simple(:sunday) do
+      DateFactories::Weekday.sunday
+    end
+
     rule month: simple(:month), day: simple(:day) do
       DateFactories::MonthDay.new(month, day)
     end

--- a/spec/lib/halftime/parser_spec.rb
+++ b/spec/lib/halftime/parser_spec.rb
@@ -98,6 +98,36 @@ describe Halftime::Parser do
         specify { expect(time("feb09")).to eq Time.new(2015, 2, 9, 12, 0, 0, 0) }
         specify { expect(time("tomorrow")).to eq Time.new(2014, 11, 15, 12, 0, 0, 0) }
         specify { expect(time("Tomorrow")).to eq Time.new(2014, 11, 15, 12, 0, 0, 0) }
+        specify { expect(time("monday")).to eq Time.new(2014, 11, 17, 12, 0, 0, 0) }
+        specify { expect(time("Monday")).to eq Time.new(2014, 11, 17, 12, 0, 0, 0) }
+        specify { expect(time("mon")).to eq Time.new(2014, 11, 17, 12, 0, 0, 0) }
+        specify { expect(time("Mon")).to eq Time.new(2014, 11, 17, 12, 0, 0, 0) }
+        specify { expect(time("next monday")).to eq Time.new(2014, 11, 17, 12, 0, 0, 0) }
+        specify { expect(time("tuesday")).to eq Time.new(2014, 11, 18, 12, 0, 0, 0) }
+        specify { expect(time("Tuesday")).to eq Time.new(2014, 11, 18, 12, 0, 0, 0) }
+        specify { expect(time("tue")).to eq Time.new(2014, 11, 18, 12, 0, 0, 0) }
+        specify { expect(time("Next tue")).to eq Time.new(2014, 11, 18, 12, 0, 0, 0) }
+        specify { expect(time("Tue")).to eq Time.new(2014, 11, 18, 12, 0, 0, 0) }
+        specify { expect(time("wednesday")).to eq Time.new(2014, 11, 19, 12, 0, 0, 0) }
+        specify { expect(time("Wednesday")).to eq Time.new(2014, 11, 19, 12, 0, 0, 0) }
+        specify { expect(time("wed")).to eq Time.new(2014, 11, 19, 12, 0, 0, 0) }
+        specify { expect(time("Wed")).to eq Time.new(2014, 11, 19, 12, 0, 0, 0) }
+        specify { expect(time("thursday")).to eq Time.new(2014, 11, 20, 12, 0, 0, 0) }
+        specify { expect(time("Thursday")).to eq Time.new(2014, 11, 20, 12, 0, 0, 0) }
+        specify { expect(time("thu")).to eq Time.new(2014, 11, 20, 12, 0, 0, 0) }
+        specify { expect(time("Thu")).to eq Time.new(2014, 11, 20, 12, 0, 0, 0) }
+        specify { expect(time("friday")).to eq Time.new(2014, 11, 21, 12, 0, 0, 0) }
+        specify { expect(time("Friday")).to eq Time.new(2014, 11, 21, 12, 0, 0, 0) }
+        specify { expect(time("fri")).to eq Time.new(2014, 11, 21, 12, 0, 0, 0) }
+        specify { expect(time("Fri")).to eq Time.new(2014, 11, 21, 12, 0, 0, 0) }
+        specify { expect(time("saturday")).to eq Time.new(2014, 11, 15, 12, 0, 0, 0) }
+        specify { expect(time("Saturday")).to eq Time.new(2014, 11, 15, 12, 0, 0, 0) }
+        specify { expect(time("sat")).to eq Time.new(2014, 11, 15, 12, 0, 0, 0) }
+        specify { expect(time("Sat")).to eq Time.new(2014, 11, 15, 12, 0, 0, 0) }
+        specify { expect(time("sunday")).to eq Time.new(2014, 11, 16, 12, 0, 0, 0) }
+        specify { expect(time("Sunday")).to eq Time.new(2014, 11, 16, 12, 0, 0, 0) }
+        specify { expect(time("sun")).to eq Time.new(2014, 11, 16, 12, 0, 0, 0) }
+        specify { expect(time("Sun")).to eq Time.new(2014, 11, 16, 12, 0, 0, 0) }
       end
 
       describe "year, month and day" do
@@ -160,6 +190,9 @@ describe Halftime::Parser do
         specify { expect(time("4am tomorrow")).to eq Time.new(2014, 11, 15, 4, 0, 0, 0) }
         specify { expect(time("17 tomorrow")).to eq Time.new(2014, 11, 15, 17, 0, 0, 0) }
         specify { expect(time("@ 3 tomorrow")).to eq Time.new(2014, 11, 15, 3, 0, 0, 0) }
+        specify { expect(time("monday 3pm")).to eq Time.new(2014, 11, 17, 15, 0, 0, 0) }
+        specify { expect(time("15 next monday")).to eq Time.new(2014, 11, 17, 15, 0, 0, 0) }
+        specify { expect(time("1 on Tue")).to eq Time.new(2014, 11, 18, 1, 0, 0, 0) }
       end
 
       describe "month, day, hours and minutes" do
@@ -191,6 +224,8 @@ describe Halftime::Parser do
         specify { expect(time("@ 0353 tomorrow")).to eq Time.new(2014, 11, 15, 3, 53, 0, 0) }
         specify { expect(time("at19.33 tomorrow")).to eq Time.new(2014, 11, 15, 19, 33, 0, 0) }
         specify { expect(time("1130 tomorrow")).to eq Time.new(2014, 11, 15, 11, 30, 0, 0) }
+        specify { expect(time("@ 01.10 Wednesday")).to eq Time.new(2014, 11, 19, 1, 10, 0, 0) }
+        specify { expect(time("thu at 20:22")).to eq Time.new(2014, 11, 20, 20, 22, 0, 0) }
       end
 
       describe "year, month, day and hours" do
@@ -254,6 +289,34 @@ describe Halftime::Parser do
       describe "month and day" do
         specify { expect(time("tomorrow")).to eq Time.new(2015, 1, 1, 12, 0, 0, 0) }
         specify { expect(time("Tomorrow")).to eq Time.new(2015, 1, 1, 12, 0, 0, 0) }
+        specify { expect(time("monday")).to eq Time.new(2015, 1, 5, 12, 0, 0, 0) }
+        specify { expect(time("Monday")).to eq Time.new(2015, 1, 5, 12, 0, 0, 0) }
+        specify { expect(time("mon")).to eq Time.new(2015, 1, 5, 12, 0, 0, 0) }
+        specify { expect(time("Mon")).to eq Time.new(2015, 1, 5, 12, 0, 0, 0) }
+        specify { expect(time("tuesday")).to eq Time.new(2015, 1, 6, 12, 0, 0, 0) }
+        specify { expect(time("Tuesday")).to eq Time.new(2015, 1, 6, 12, 0, 0, 0) }
+        specify { expect(time("tue")).to eq Time.new(2015, 1, 6, 12, 0, 0, 0) }
+        specify { expect(time("Tue")).to eq Time.new(2015, 1, 6, 12, 0, 0, 0) }
+        specify { expect(time("wednesday")).to eq Time.new(2015, 1, 7, 12, 0, 0, 0) }
+        specify { expect(time("Wednesday")).to eq Time.new(2015, 1, 7, 12, 0, 0, 0) }
+        specify { expect(time("wed")).to eq Time.new(2015, 1, 7, 12, 0, 0, 0) }
+        specify { expect(time("Wed")).to eq Time.new(2015, 1, 7, 12, 0, 0, 0) }
+        specify { expect(time("thursday")).to eq Time.new(2015, 1, 1, 12, 0, 0, 0) }
+        specify { expect(time("Thursday")).to eq Time.new(2015, 1, 1, 12, 0, 0, 0) }
+        specify { expect(time("thu")).to eq Time.new(2015, 1, 1, 12, 0, 0, 0) }
+        specify { expect(time("Thu")).to eq Time.new(2015, 1, 1, 12, 0, 0, 0) }
+        specify { expect(time("friday")).to eq Time.new(2015, 1, 2, 12, 0, 0, 0) }
+        specify { expect(time("Friday")).to eq Time.new(2015, 1, 2, 12, 0, 0, 0) }
+        specify { expect(time("fri")).to eq Time.new(2015, 1, 2, 12, 0, 0, 0) }
+        specify { expect(time("Fri")).to eq Time.new(2015, 1, 2, 12, 0, 0, 0) }
+        specify { expect(time("saturday")).to eq Time.new(2015, 1, 3, 12, 0, 0, 0) }
+        specify { expect(time("Saturday")).to eq Time.new(2015, 1, 3, 12, 0, 0, 0) }
+        specify { expect(time("sat")).to eq Time.new(2015, 1, 3, 12, 0, 0, 0) }
+        specify { expect(time("Sat")).to eq Time.new(2015, 1, 3, 12, 0, 0, 0) }
+        specify { expect(time("sunday")).to eq Time.new(2015, 1, 4, 12, 0, 0, 0) }
+        specify { expect(time("Sunday")).to eq Time.new(2015, 1, 4, 12, 0, 0, 0) }
+        specify { expect(time("sun")).to eq Time.new(2015, 1, 4, 12, 0, 0, 0) }
+        specify { expect(time("Sun")).to eq Time.new(2015, 1, 4, 12, 0, 0, 0) }
       end
     end
 


### PR DESCRIPTION
Names of weekdays are parsed to the next occurrence of that weekday relative
to the current date. Weekday names can optionally be prepended with the word
"next".

Closes #3.
